### PR TITLE
Added recursion error handling in remove_invalid_urls

### DIFF
--- a/email2pdf2/email2pdf2.py
+++ b/email2pdf2/email2pdf2.py
@@ -499,7 +499,11 @@ def remove_invalid_urls(payload):
             else:
                 logger.debug("Ignoring URL " + src)
 
-    return str(soup)
+    try:
+        return str(soup)
+    except RecursionError:
+        logger.warning("RecursionError while serializing HTML (deeply nested elements), skipping URL validation.")
+        return payload
 
 
 def can_url_fetch(src):


### PR DESCRIPTION
@sgeulette Qu'est-ce qui est le mieux entre laisser l'erreur se produire et envoyer le eml vers iA.Docs, ou ajouter cette exception, convertir en pdf mais ne pas gérer les urls invalides ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when processing emails with deeply nested HTML structures to prevent application crashes during format conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->